### PR TITLE
Error stacktrace propagation

### DIFF
--- a/lib/NatsBarrel.js
+++ b/lib/NatsBarrel.js
@@ -15,14 +15,20 @@ let natsbarrel = NatsBarrel.prototype
 
 let SEPARATOR = '.'
 
-let errorAttribs = [ 'code', 'message', 'errorCode', 'id', 'reason', 'params' ]
+let errorAttribs = [ 'code', 'message', 'errorCode', 'id', 'reason', 'params', 'stack' ]
 
 
 const fs = require('fs')
 const path = require('path')
 let VERSION = exports.VERSION = JSON.parse( fs.readFileSync( path.join( process.cwd(), 'package.json'), 'utf8' ) ).version
 
+function removeHarconFrames (stack) {
+	let nonHarconPart = stack.split("Firestarter.js")[0]
 
+	let lastAt = nonHarconPart.lastIndexOf('at ')
+
+	return nonHarconPart.slice(0, lastAt).trim()
+}
 function printError (err) {
 	let res = {}
 	for (let attrib of errorAttribs)
@@ -30,6 +36,7 @@ function printError (err) {
 			res[ attrib ] = err[attrib]
 
 	res.message = err.message || err.toString()
+	res.stack = removeHarconFrames(err.stack);
 	return res
 }
 function buildError (obj) {


### PR DESCRIPTION
Hi!

I've added error stacktrace propagation to NatsBarrel, so stacktraces are preserved within Harcon requests.

Would you please be so kind as to review these changes if they could fit into the library?

Thanks!